### PR TITLE
Check Italian translation to fix issue #4

### DIFF
--- a/src/main/resources/MessagesBundle_it_IT.properties
+++ b/src/main/resources/MessagesBundle_it_IT.properties
@@ -1,9 +1,9 @@
 window.title 			= JCopy - Simple backup
 
-items.add 				= Aggiungi directory
+items.add 				= Aggiungi cartella
 items.removeItem 		= Rimuovi dall'elenco
 items.removeAll			= Cancella elenco
 
-destination				= directory di destinazione
-destination.select		= Selezionare la directory di destinazione del backup
-start					= Avviare il backup
+destination				= Cartella di destinazione
+destination.select		= Seleziona la cartella di destinazione del backup
+start					= Avvia il backup


### PR DESCRIPTION
I translated "directory" in "cartella" (which is the common name used in Italy to identify both "folders" and "directories" in general.
I also uniformed verb tenses (all imperatives, no infinites)